### PR TITLE
Add stage, tile, and unit models

### DIFF
--- a/lib/models/stage.dart
+++ b/lib/models/stage.dart
@@ -1,0 +1,68 @@
+import 'tile.dart';
+import 'unit.dart';
+
+const int stageWidth = 24;
+const int stageHeight = 16;
+
+class UnitPlacement {
+  final int x;
+  final int y;
+  final Unit unit;
+
+  UnitPlacement({required this.x, required this.y, required this.unit});
+
+  factory UnitPlacement.fromJson(Map<String, dynamic> json) {
+    return UnitPlacement(
+      x: json['x'] as int,
+      y: json['y'] as int,
+      unit: Unit.fromJson(json['unit'] as Map<String, dynamic>),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'x': x,
+        'y': y,
+        'unit': unit.toJson(),
+      };
+}
+
+class Stage {
+  final List<List<Tile>> tiles;
+  final List<UnitPlacement> units;
+
+  Stage({required this.tiles, required this.units});
+
+  factory Stage.empty() {
+    return Stage(
+      tiles: List.generate(
+        stageHeight,
+        (_) => List.generate(
+          stageWidth,
+          (_) => Tile(terrainType: 'plain'),
+        ),
+      ),
+      units: [],
+    );
+  }
+
+  factory Stage.fromJson(Map<String, dynamic> json) {
+    var tilesJson = json['tiles'] as List<dynamic>;
+    var tilesList = tilesJson
+        .map((row) =>
+            (row as List).map((tile) => Tile.fromJson(tile)).toList())
+        .toList();
+    var unitsJson = json['units'] as List<dynamic>;
+    var unitList =
+        unitsJson.map((u) => UnitPlacement.fromJson(u)).toList();
+    return Stage(
+      tiles: tilesList.cast<List<Tile>>(),
+      units: unitList,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'tiles':
+            tiles.map((row) => row.map((t) => t.toJson()).toList()).toList(),
+        'units': units.map((u) => u.toJson()).toList(),
+      };
+}

--- a/lib/models/tile.dart
+++ b/lib/models/tile.dart
@@ -1,0 +1,19 @@
+class Tile {
+  final String terrainType;
+  final Map<String, dynamic> effects;
+
+  Tile({required this.terrainType, Map<String, dynamic>? effects})
+      : effects = effects ?? {};
+
+  factory Tile.fromJson(Map<String, dynamic> json) {
+    return Tile(
+      terrainType: json['terrainType'] as String,
+      effects: Map<String, dynamic>.from(json['effects'] as Map? ?? {}),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'terrainType': terrainType,
+        'effects': effects,
+      };
+}

--- a/lib/models/unit.dart
+++ b/lib/models/unit.dart
@@ -1,0 +1,21 @@
+class Unit {
+  int hp;
+  int mobility;
+  String affinity;
+
+  Unit({required this.hp, required this.mobility, required this.affinity});
+
+  factory Unit.fromJson(Map<String, dynamic> json) {
+    return Unit(
+      hp: json['hp'] as int,
+      mobility: json['mobility'] as int,
+      affinity: json['affinity'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'hp': hp,
+        'mobility': mobility,
+        'affinity': affinity,
+      };
+}


### PR DESCRIPTION
## Summary
- model game stage basics with `Tile`, `Unit`, and `Stage`
- support JSON serialization for saving/loading

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a55a6a70832a939d4cb3944432ac