### PR TITLE
Add map editing providers

### DIFF
--- a/lib/models/map_tile.dart
+++ b/lib/models/map_tile.dart
@@ -1,0 +1,11 @@
+class MapTile {
+  final String terrain;
+
+  MapTile({required this.terrain});
+
+  factory MapTile.fromJson(Map<String, dynamic> json) {
+    return MapTile(terrain: json['terrain'] as String);
+  }
+
+  Map<String, dynamic> toJson() => {'terrain': terrain};
+}

--- a/lib/providers/map_data_provider.dart
+++ b/lib/providers/map_data_provider.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/map_tile.dart';
+import '../models/stage.dart';
+
+/// [MapDataNotifier] manages a grid of [MapTile]s for the map editor.
+class MapDataNotifier extends StateNotifier<List<List<MapTile>>> {
+  MapDataNotifier()
+      : super(List.generate(
+          stageHeight,
+          (_) => List.generate(
+            stageWidth,
+            (_) => MapTile(terrain: 'plain'),
+          ),
+        ));
+
+  /// Load map data from a JSON file at [path].
+  Future<void> loadStage(String path) async {
+    final file = File(path);
+    if (!await file.exists()) return;
+    final content = await file.readAsString();
+    final data = jsonDecode(content) as List<dynamic>;
+    final grid = data
+        .map((row) => (row as List)
+            .map((tile) => MapTile.fromJson(tile as Map<String, dynamic>))
+            .toList())
+        .toList();
+    state = grid.cast<List<MapTile>>();
+  }
+
+  /// Save the current map data to a JSON file at [path].
+  Future<void> saveStage(String path) async {
+    final file = File(path);
+    final data = jsonEncode(
+      state.map((row) => row.map((t) => t.toJson()).toList()).toList(),
+    );
+    await file.writeAsString(data);
+  }
+
+  /// Update the tile at coordinates ([x], [y]) to the given [terrain].
+  void updateTile(int x, int y, String terrain) {
+    if (y < 0 || y >= state.length) return;
+    if (x < 0 || x >= state[y].length) return;
+    state[y][x] = MapTile(terrain: terrain);
+    state = [for (final row in state) [...row]];
+  }
+}
+
+/// Provider exposing the [MapDataNotifier].
+final mapDataProvider =
+    StateNotifierProvider<MapDataNotifier, List<List<MapTile>>>(
+        (ref) => MapDataNotifier());

--- a/lib/providers/tile_palette_provider.dart
+++ b/lib/providers/tile_palette_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the list of available terrain types for the editor palette.
+final tilePaletteProvider = Provider<List<String>>((ref) {
+  return ['plain', 'forest', 'mountain', 'river', 'fort'];
+});
+
+/// Holds the currently selected terrain type from the palette.
+final selectedTerrainProvider = StateProvider<String>((ref) => 'plain');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   flutter_riverpod: ^2.5.0
+  hooks_riverpod: ^2.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add MapTile model for terrain information
- add tilePaletteProvider and selectedTerrainProvider
- add MapDataNotifier and mapDataProvider for map editing
- include hooks_riverpod in pubspec

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f7342fb0832ab0210ffc40140870