### PR TITLE
Implement basic editor scaffold

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'widgets/main_scaffold.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+    return const MaterialApp(
+      title: 'Stage Editor',
+      home: MainScaffold(),
     );
   }
 }

--- a/lib/providers/selected_tile_provider.dart
+++ b/lib/providers/selected_tile_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Holds the currently selected tile coordinates on the map canvas.
+/// `null` means no tile is selected.
+final selectedTileProvider = StateProvider<(int x, int y)?>(
+  (ref) => null,
+);

--- a/lib/widgets/inspector_widget.dart
+++ b/lib/widgets/inspector_widget.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/map_data_provider.dart';
+import '../providers/selected_tile_provider.dart';
+
+/// Displays information about the currently selected tile.
+class InspectorWidget extends ConsumerWidget {
+  const InspectorWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = ref.watch(selectedTileProvider);
+    final mapData = ref.watch(mapDataProvider);
+
+    if (selected == null) {
+      return const Center(child: Text('No tile selected'));
+    }
+
+    final tile = mapData[selected.$2][selected.$1];
+    return Center(
+      child: Text('(${selected.$1}, ${selected.$2}): ${tile.terrain}'),
+    );
+  }
+}

--- a/lib/widgets/main_scaffold.dart
+++ b/lib/widgets/main_scaffold.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+import 'tile_palette_widget.dart';
+import 'unit_palette_widget.dart';
+import 'map_canvas_widget.dart';
+import 'inspector_widget.dart';
+
+/// Overall layout for the editor screen.
+class MainScaffold extends StatelessWidget {
+  const MainScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Stage Editor')),
+      body: Column(
+        children: const [
+          Expanded(
+            child: Row(
+              children: [
+                SizedBox(width: 200, child: TilePaletteWidget()),
+                Expanded(child: MapCanvasWidget()),
+                SizedBox(width: 200, child: UnitPaletteWidget()),
+              ],
+            ),
+          ),
+          SizedBox(height: 120, child: InspectorWidget()),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/map_canvas_widget.dart
+++ b/lib/widgets/map_canvas_widget.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/stage.dart';
+import '../providers/map_data_provider.dart';
+import '../providers/selected_tile_provider.dart';
+import '../providers/tile_palette_provider.dart';
+
+/// Canvas that displays the map grid and handles tile updates.
+class MapCanvasWidget extends ConsumerWidget {
+  const MapCanvasWidget({super.key});
+
+  Color _terrainColor(String terrain) {
+    switch (terrain) {
+      case 'plain':
+        return Colors.green;
+      case 'forest':
+        return Colors.greenAccent;
+      case 'mountain':
+        return Colors.brown;
+      case 'river':
+        return Colors.blue;
+      case 'fort':
+        return Colors.red;
+      default:
+        return Colors.grey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mapData = ref.watch(mapDataProvider);
+    final selectedTerrain = ref.watch(selectedTerrainProvider);
+    final selectedTile = ref.watch(selectedTileProvider);
+    final notifier = ref.read(mapDataProvider.notifier);
+
+    return GridView.builder(
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: stageWidth,
+      ),
+      itemCount: stageWidth * stageHeight,
+      itemBuilder: (context, index) {
+        final x = index % stageWidth;
+        final y = index ~/ stageWidth;
+        final tile = mapData[y][x];
+        final isSelected = selectedTile != null &&
+            selectedTile.$1 == x &&
+            selectedTile.$2 == y;
+        return GestureDetector(
+          onTap: () {
+            notifier.updateTile(x, y, selectedTerrain);
+            ref.read(selectedTileProvider.notifier).state = (x: x, y: y);
+          },
+          child: Container(
+            margin: const EdgeInsets.all(1),
+            decoration: BoxDecoration(
+              color: _terrainColor(tile.terrain),
+              border: isSelected
+                  ? Border.all(color: Colors.yellow, width: 2)
+                  : Border.all(color: Colors.black12),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/tile_palette_widget.dart
+++ b/lib/widgets/tile_palette_widget.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/tile_palette_provider.dart';
+
+/// Palette for selecting terrain types.
+class TilePaletteWidget extends ConsumerWidget {
+  const TilePaletteWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final terrains = ref.watch(tilePaletteProvider);
+    final selected = ref.watch(selectedTerrainProvider);
+    return ListView(
+      children: [
+        for (final t in terrains)
+          ListTile(
+            title: Text(t),
+            selected: t == selected,
+            onTap: () =>
+                ref.read(selectedTerrainProvider.notifier).state = t,
+          ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/unit_palette_widget.dart
+++ b/lib/widgets/unit_palette_widget.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder widget for the unit palette.
+class UnitPaletteWidget extends StatelessWidget {
+  const UnitPaletteWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('Unit Palette'));
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,17 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:gameoffe/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App loads with stage editor title', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MyApp()),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Stage Editor'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- wrap app with `ProviderScope` and launch new `MainScaffold`
- create provider to store selected tile
- add tile palette, unit palette, map canvas, and inspector widgets
- implement map editing logic with tile selection
- update widget tests for new app

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fdd32508832aa3d6df25e8f9984f