### PR TITLE
Fix selected tile assignment

### DIFF
--- a/lib/widgets/map_canvas_widget.dart
+++ b/lib/widgets/map_canvas_widget.dart
@@ -49,7 +49,7 @@ class MapCanvasWidget extends ConsumerWidget {
         return GestureDetector(
           onTap: () {
             notifier.updateTile(x, y, selectedTerrain);
-            ref.read(selectedTileProvider.notifier).state = (x: x, y: y);
+            ref.read(selectedTileProvider.notifier).state = (x, y);
           },
           child: Container(
             margin: const EdgeInsets.all(1),


### PR DESCRIPTION
## Summary
- fix compile error in `MapCanvasWidget` when assigning selected tile coordinates

## Testing
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_6857ffbf45ac832ab634d21501ed707b